### PR TITLE
Make building glimmer into Ember optional.

### DIFF
--- a/bin/build_ember
+++ b/bin/build_ember
@@ -45,15 +45,17 @@ each_experiment do |experiment|
 
   h2 "Setup"
 
-  in_glimmer do
-    run "rm -rf dist"
+  if experiment['glimmer']
+    in_glimmer do
+      run "rm -rf dist"
 
-    run "git checkout #{experiment['glimmer']}"
+      run "git checkout #{experiment['glimmer']}"
 
-    run "npm install"
-    run "bower install"
+      run "npm install"
+      run "bower install"
 
-    run build_command_for("glimmer")
+      run build_command_for("glimmer")
+    end
   end
 
   in_ember do
@@ -67,7 +69,7 @@ each_experiment do |experiment|
     run "npm install"
     run "bower install"
 
-    run "npm link glimmer-engine"
+    run "npm link glimmer-engine" if experiment['glimmer']
 
     puts
     puts "Re-writing features.json..."

--- a/bin/check
+++ b/bin/check
@@ -78,17 +78,17 @@ $EXPERIMENTS.each_with_index do |experiment, i|
   end
 
   ["app", "ember", "glimmer"].each do |project|
-    Dir.chdir($PROJECTS[project]["path"]) do
-      puts "  #{project}"
+    if experiment[project]
+      Dir.chdir($PROJECTS[project]["path"]) do
+        puts "  #{project}"
 
-      rev = experiment[project]
-      short_name = (rev =~ /[0-9a-f]{40}/ ? rev[0...7] : rev)
+        rev = experiment[project]
+        short_name = (rev =~ /[0-9a-f]{40}/ ? rev[0...7] : rev)
 
-      check_command "    Is valid git checkout", "git rev-parse --verify --quiet #{rev}", info: short_name, error_message: "#{rev} is not a valid git checkout for #{project}"
+        check_command "    Is valid git checkout", "git rev-parse --verify --quiet #{rev}", info: short_name, error_message: "#{rev} is not a valid git checkout for #{project}"
+      end
     end
   end
 end
 
 h1 "LGTM!", color: :green
-
-


### PR DESCRIPTION
When the Ember being built contains the correct glimmer version, there is no reason to build glimmer manually.

This is complimentary to #10 (which makes building Ember optional).
