### PR TITLE
Prevent errors from ember-cli-dependency-checker.

### DIFF
--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -138,7 +138,7 @@ module Utils
 
   def build_command_for(project)
     @projects ||= parse_json("config/projects.json")
-    @projects[project]["build"] || "ember build -prod"
+    @projects[project]["build"] || "SKIP_DEPENDENCY_CHECKER=true ember build -prod"
   end
 
   def here(**options)


### PR DESCRIPTION
In many cases this should allow the app to be tested on its `master` branch without special modifications to allow `*` for `ember`.
