### PR TITLE
Add `conf.int` to wilcox test.

### DIFF
--- a/bin/plot
+++ b/bin/plot
@@ -6,7 +6,7 @@ samples = read.csv('stdin')
 wilcox.test(ms ~ set, data=samples)
 
 svg(file = "boxplot.svg")
-boxplot(ms ~ set, data=samples)
+boxplot(ms ~ set, data=samples, conf.int=TRUE)
 dev.off()
 
 require(lattice)


### PR DESCRIPTION
Requested by @krisselden after a round of testing, and seemed generally useful to have:

> this shows you the range it is 95% confident the location shift was within

Given:

```
    Wilcoxon rank sum test with continuity correction

data:  ms by set
W = 3499, p-value = 0.009923
alternative hypothesis: true location shift is not equal to 0
95 percent confidence interval:
  4.185039 30.244932
sample estimates:
difference in location
              17.92599
```

> 95% chance the shift was between 4ms and 30ms and 18ms median
